### PR TITLE
Embed version in executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .bash_history
 vendor/
+version.txt

--- a/cmd/widgetsservice/main.go
+++ b/cmd/widgetsservice/main.go
@@ -5,5 +5,5 @@ import (
 )
 
 func main() {
-	widgetsService.Run()
+	widgetsService.Run(version)
 }

--- a/cmd/widgetsservice/version.go
+++ b/cmd/widgetsservice/version.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	_ "embed"
+)
+
+//go:generate ../../scripts/version.sh cmd/widgetsservice
+//go:embed version.txt
+var version string

--- a/pkg/widgets/service/grpcserver.go
+++ b/pkg/widgets/service/grpcserver.go
@@ -29,7 +29,7 @@ func (g *GRPCService) Stop() {
 // package and starts the GRPC service.
 func (s *Service) StartGRPCService() error {
 
-	s.Logger.Info().Msg("Start GRPCService")
+	s.Logger.Info().Msgf("Start GRPCService %s", s.Version)
 	grpcServer := grpc.NewServer(
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			grpc_validator.UnaryServerInterceptor(),

--- a/pkg/widgets/service/runner.go
+++ b/pkg/widgets/service/runner.go
@@ -37,10 +37,11 @@ func port() string {
 // Run initializes the Service struct and executes its Run method.
 // The Service struct specifies the grpc server code and any other interfaces
 // to external services defined in connections.go.
-func Run() {
+func Run(version string) {
 	var err error
 
 	s := Service{
+		Version: version,
 		Logger: &logger.Logger{
 			Level:       logLevel(),
 			ServiceName: serviceName,

--- a/pkg/widgets/service/service.go
+++ b/pkg/widgets/service/service.go
@@ -13,6 +13,9 @@ type loggerContextKey string
 type Service struct {
 	widgetsAPI.UnimplementedWidgetsServer
 
+	// Version of application
+	Version string
+
 	// An interface as we may want to mock it out in tests.
 	Logger LoggerInterface
 

--- a/scripts/grpcserver.sh
+++ b/scripts/grpcserver.sh
@@ -53,6 +53,9 @@ type loggerContextKey string
 type Service struct {
 	${UNIMPLEMENTED}
 
+	// Version of application
+	Version string
+
 	// An interface as we may want to mock it out in tests.
 	Logger LoggerInterface
 
@@ -113,7 +116,7 @@ func (g *GRPCService) Stop() {
 // package and starts the GRPC service.
 func (s *Service) StartGRPCService() error {
 
-	s.Logger.Info().Msg("Start GRPCService")
+	s.Logger.Info().Msgf("Start GRPCService %s", s.Version)
 	grpcServer := grpc.NewServer(
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(
 			grpc_validator.UnaryServerInterceptor(),

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Generates a version file for embedding in application
+#
+# #1 - must be the relative directory path
+#
+cd $( dirname $( dirname $0))
+. scripts/source/log
+
+version=$(git describe --tags --abbrev=0)
+log_info "Generate ${version} in version.txt for ${1}"
+echo ${version} > ${1}/version.txt


### PR DESCRIPTION
Problem:
Tracebility of installed executable back to specific
commit is not possible.

Solution:
Embedded version in buit executable using go:generate and
go:embed.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>