### PR TITLE
Golangci-lint upgrade

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -199,7 +199,8 @@ linters-settings:
     # put imports beginning with prefix after 3rd-party packages;
     # only support one prefix
     # if not set, use goimports.local-prefixes
-    local-prefixes: github.com/org/project
+    # local-prefixes: github.com/eccles/hestia
+    sections: prefix(github.com/eccles/hestia)
 
   gocognit:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
@@ -796,6 +797,7 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+    - gci
     - golint
     - interfacer
     - maligned

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ generate: ## generate code such as proto stuff
 qa: ## quality check all source code
 	@go mod vendor
 	@gofmt -l -s -w $(shell find . -type f -name '*.go'| grep -v "/vendor/\|/.git/")
-	@golangci-lint run
+	@golangci-lint run -v
 	@go mod tidy
 	@go mod verify
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -14,7 +14,6 @@ const (
 // Logger represents an interface to a typical logger including logging
 // levels, format control and others to be elucidated in future commits.
 type Logger struct {
-
 	// Service - the logger has this field add as "service"
 	ServiceName string
 

--- a/pkg/widgets/service/handlers.go
+++ b/pkg/widgets/service/handlers.go
@@ -3,8 +3,9 @@ package widgetsService
 import (
 	"context"
 
-	widgetsAPI "github.com/eccles/hestia/pkg/apis/widgets"
 	empty "google.golang.org/protobuf/types/known/emptypb"
+
+	widgetsAPI "github.com/eccles/hestia/pkg/apis/widgets"
 )
 
 func (s *Service) Create(

--- a/scripts/tools/source/golangci-lint
+++ b/scripts/tools/source/golangci-lint
@@ -7,7 +7,7 @@
 . ./scripts/source/environment
 
 GOLANG_LINT_CMD=golangci-lint
-GOLANG_LINT_VERSION=1.44.0
+GOLANG_LINT_VERSION=1.45.2
 
 golangci-lint_install() {
         TEMPDIR=$( mktemp -d /tmp/.${GOLANG_LINT_CMD}.XXXXXXXX )


### PR DESCRIPTION
Problem:
Go 1.18 requires upgrade golangci-lint to 1.45.2

Solution:
Upgrade golangci-lint to 1.45.2 - disabled gci linter as
superfluous.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>