### PR TITLE
Upgrade Go 1.18.1

### DIFF
--- a/scripts/tools/source/go
+++ b/scripts/tools/source/go
@@ -6,7 +6,7 @@
 . ./scripts/source/log
 . ./scripts/source/environment
 
-GOLANG_VERSION=1.17.8
+GOLANG_VERSION=1.18.1
 GOLANG_CMD=go
 
 go_install() {

--- a/scripts/tools/source/mockery
+++ b/scripts/tools/source/mockery
@@ -6,7 +6,7 @@
 . ./scripts/source/log
 . ./scripts/source/environment
 
-MOCKERY_VERSION=2.10.0
+MOCKERY_VERSION=2.12.2
 MOCKERY_CMD=mockery
 
 mockery_install() {


### PR DESCRIPTION
Problem:
Upgrade to Go 1.18.1

Solution:
Also upgraded mockery to 2.12.2 to get rid of error.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>